### PR TITLE
Remove duplicate attendee listing for Andy Piper

### DIFF
--- a/meetings/2026/2026-03-06-WG-kickoff.md
+++ b/meetings/2026/2026-03-06-WG-kickoff.md
@@ -16,7 +16,6 @@ Charter: https://www.w3.org/2026/01/social-web-wg-charter.html
 * Aaron Parecki
 * Dmitri Zagidulin
 * Steve Blackmon
-* Andy Piper
 * David Roetzel, Mastodon
 * Eugen Rochko, Mastodon
 * Philippe Le Hegaret, W3C


### PR DESCRIPTION
Removed duplicate entry for Andy Piper in the attendee list. (GitHub seems to have messed with the whitespace at the end of the file)